### PR TITLE
🤖 #36: greet_all は hello のみ呼ぶが関数名が汎用的で誤解を招く — hello_all にリネームすべき

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -21,6 +21,6 @@ def goodbye(name):
     return f"Goodbye, {name}!"
 
 
-def greet_all(names):
-    logger.debug("greet_all called with %d name(s)", len(names))
+def hello_all(names):
+    logger.debug("hello_all called with %d name(s)", len(names))
     return [hello(name) for name in names]

--- a/test_hello.py
+++ b/test_hello.py
@@ -1,4 +1,4 @@
-from hello import hello, goodbye, greet_all
+from hello import hello, goodbye, hello_all
 
 
 def test_hello():
@@ -9,12 +9,12 @@ def test_goodbye():
     assert goodbye("World") == "Goodbye, World!"
 
 
-def test_greet_all():
-    assert greet_all(["Alice", "Bob"]) == ["Hello, Alice!", "Hello, Bob!"]
+def test_hello_all():
+    assert hello_all(["Alice", "Bob"]) == ["Hello, Alice!", "Hello, Bob!"]
 
 
-def test_greet_all_empty():
-    assert greet_all([]) == []
+def test_hello_all_empty():
+    assert hello_all([]) == []
 
 
 def test_hello_empty_string():


### PR DESCRIPTION
## Summary
Closes #36

この PR は Claude Code によって自動生成されました。

## Issue
greet_all は hello のみ呼ぶが関数名が汎用的で誤解を招く — hello_all にリネームすべき

## 変更内容
54bb17b Rename greet_all to hello_all to match actual behavior (#36)

---
⚠️ **人間によるレビューが必要です。** マージ前にコードを確認してください。

🤖 Generated by [claude-runner](https://github.com/taku-me/claude-runner)