### PR TITLE
🤖 #51: run-task.sh で git checkout main 後に未追跡ファイルを削除しておらず前回の残骸が次の PR に混入する

### DIFF
--- a/run-task.sh
+++ b/run-task.sh
@@ -74,6 +74,8 @@ if [[ -d "$WORK_DIR/.git" ]]; then
   log "既存のローカルリポジトリを更新"
   cd "$WORK_DIR"
   git checkout main 2>/dev/null || git checkout master
+  git clean -fd
+  git checkout -- .
   git pull --ff-only
 else
   log "リポジトリをクローン"


### PR DESCRIPTION
## Summary
Closes #51

この PR は Claude Code によって自動生成されました。

## Issue
run-task.sh で git checkout main 後に未追跡ファイルを削除しておらず前回の残骸が次の PR に混入する

## 変更内容
2a9b201 Clean working tree before pulling in run-task.sh (#51)

---
⚠️ **人間によるレビューが必要です。** マージ前にコードを確認してください。

🤖 Generated by [claude-runner](https://github.com/taku-me/claude-runner)