### PR TITLE
🤖 #52: analyze.sh の既存 Issue 取得が gh のデフォルト上限 30 件に制限されており重複 Issue が作成される

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -58,7 +58,7 @@ fi
 
 # --- 既存 Issue のタイトル一覧を取得 ---
 log "既存の Issue を確認中..."
-EXISTING_ISSUES=$(gh issue list --repo "$REPO" --state open --json title --jq '.[].title' 2>/dev/null || true)
+EXISTING_ISSUES=$(gh issue list --repo "$REPO" --state all --limit 500 --json title --jq '.[].title' 2>/dev/null || true)
 
 # --- Claude Code で分析 ---
 PROMPT="あなたはこのリポジトリのコードレビュアーです。コードベースを読んで改善点を洗い出し、GitHub Issue として提案してください。


### PR DESCRIPTION
## Summary
Closes #52

この PR は Claude Code によって自動生成されました。

## Issue
analyze.sh の既存 Issue 取得が gh のデフォルト上限 30 件に制限されており重複 Issue が作成される

## 変更内容
2db76cc Fix gh issue list default limit causing duplicate issues (#52)

---
⚠️ **人間によるレビューが必要です。** マージ前にコードを確認してください。

🤖 Generated by [claude-runner](https://github.com/taku-me/claude-runner)