### PR TITLE
🤖 #49: watcher.sh が失敗した Issue も processed に記録し再試行できない

### DIFF
--- a/watcher.sh
+++ b/watcher.sh
@@ -112,11 +112,10 @@ main() {
             --issue "$ISSUE_NUM" \
             --max-turns "$MAX_TURNS"; then
           log "  #${ISSUE_NUM}: 成功"
+          mark_processed "$ISSUE_NUM"
         else
           log "  #${ISSUE_NUM}: 失敗 (exit code: $?)"
         fi
-
-        mark_processed "$ISSUE_NUM"
 
         # タスク間に少し間を空ける（レート制限対策）
         log "  次のタスクまで60秒待機..."


### PR DESCRIPTION
## Summary
Closes #49

この PR は Claude Code によって自動生成されました。

## Issue
watcher.sh が失敗した Issue も processed に記録し再試行できない

## 変更内容
7418066 Fix mark_processed to only record successful tasks (#49)

---
⚠️ **人間によるレビューが必要です。** マージ前にコードを確認してください。

🤖 Generated by [claude-runner](https://github.com/taku-me/claude-runner)