### PR TITLE
🤖 #59: watcher.sh の gh issue list がエラーを黙って無視し認証失効やネットワーク障害を検知できない

### DIFF
--- a/watcher.sh
+++ b/watcher.sh
@@ -76,16 +76,27 @@ main() {
 
   ensure_labels
 
+  GH_FAIL_COUNT=0
+
   while true; do
     log "--- Issue をチェック中 (label: claude-task) ---"
 
     # claude-task ラベルが付いた open Issue を取得
-    ISSUES=$(gh issue list \
+    if ! ISSUES=$(gh issue list \
       --repo "$REPO" \
       --label "claude-task" \
       --state open \
       --json number,title \
-      --limit 10 2>/dev/null || echo "[]")
+      --limit 10 2>&1); then
+      GH_FAIL_COUNT=$((GH_FAIL_COUNT + 1))
+      log "警告: gh issue list が失敗しました (${GH_FAIL_COUNT}回連続): ${ISSUES}"
+      if [[ "$GH_FAIL_COUNT" -ge 5 ]]; then
+        log "エラー: gh issue list が${GH_FAIL_COUNT}回連続で失敗しています。認証やネットワークを確認してください。"
+      fi
+      ISSUES="[]"
+    else
+      GH_FAIL_COUNT=0
+    fi
 
     COUNT=$(echo "$ISSUES" | jq 'length')
 


### PR DESCRIPTION
## Summary
Closes #59

この PR は Claude Code によって自動生成されました。

## Issue
watcher.sh の gh issue list がエラーを黙って無視し認証失効やネットワーク障害を検知できない

## 変更内容
d33ed67 Fix gh issue list silently ignoring errors in watcher.sh (#59)

---
⚠️ **人間によるレビューが必要です。** マージ前にコードを確認してください。

🤖 Generated by [claude-runner](https://github.com/taku-me/claude-runner)