### PR TITLE
🤖 #69: quantum_simulator.py: simulate_quantum_factoring に負の値を渡すと math.log2 で ValueError になる

### DIFF
--- a/quantum_simulator.py
+++ b/quantum_simulator.py
@@ -69,15 +69,15 @@ def shor_factor(n, max_attempts=100):
 def simulate_quantum_factoring(n, num_qubits=None):
     logger.debug("simulate_quantum_factoring called with n=%d, num_qubits=%s", n, num_qubits)
 
+    if n < 2:
+        return {"success": False, "error": "n must be >= 2"}
+
     if num_qubits is None:
         num_qubits = max(2 * math.ceil(math.log2(n + 1)), 4)
 
     if num_qubits > 1000:
         logger.warning("num_qubits=%d exceeds maximum of 1000", num_qubits)
         return {"success": False, "error": "num_qubits exceeds maximum of 1000"}
-
-    if n < 2:
-        return {"success": False, "error": "n must be >= 2"}
 
     if is_prime(n):
         return {"success": False, "error": f"{n} is prime"}


### PR DESCRIPTION
## Summary
Closes #69

この PR は Claude Code によって自動生成されました。

## Issue
quantum_simulator.py: simulate_quantum_factoring に負の値を渡すと math.log2 で ValueError になる

## 変更内容
1f9b769 Fix ValueError when passing negative values to simulate_quantum_factoring

---
⚠️ **人間によるレビューが必要です。** マージ前にコードを確認してください。

🤖 Generated by [claude-runner](https://github.com/taku-me/claude-runner)